### PR TITLE
feat(frontend): ability to de-select layers

### DIFF
--- a/src/pages/DataLayer/OnDemandTreeView.js
+++ b/src/pages/DataLayer/OnDemandTreeView.js
@@ -122,8 +122,13 @@ const OnDemandTreeView = ({
               isParentOfSelected(node.key) ? `alert-card-active selected` : ''
             } mb-2`}
             onClick={() => {
+              let isSameNode = false;
               setSelectedNode(node);
-              setCurrentLayer(oldLayer => {
+              const selectedLayer = setCurrentLayer(oldLayer => {
+                if (oldLayer?.key === node?.key) {
+                  isSameNode = true;
+                }
+
                 if (oldLayer) {
                   resetMap();
                 } else {
@@ -152,9 +157,13 @@ const OnDemandTreeView = ({
                 }
               });
 
+              /* if there are child nodes then expand them */
+              /* if this is a leaf node, then toggle the layer */
               return node.children
                 ? toggleExpandCollapse(id)
-                : setSelectedLayer(node);
+                : isSameNode
+                ? setSelectedNode(null) // unselect node will force corresponding layer to be unselected
+                : setSelectedLayer(node); // node is already selected; select corresponding layer
             }}
             onMouseEnter={async () => {
               setTooltipInfo(undefined);

--- a/src/pages/DataLayer/TreeView.js
+++ b/src/pages/DataLayer/TreeView.js
@@ -51,11 +51,12 @@ const TreeView = ({ data, setCurrentLayer, resetMap }) => {
       if (selectedLayer?.id === id) {
         resetMap();
         setSelectedLayer({});
+        setSelNode(null);
       } else {
         setSelectedLayer(node);
+        setSelNode(node);
       }
     }
-    setSelNode(node);
   };
 
   const toggleMetaInfo = metaURL => {


### PR DESCRIPTION
Previous commit allowed the operational layer to be toggled on/off the map, but didn't toggle the selected state of the treeview node.  This PR rectifies that.  It also adds toggling ability (both layer and node) to on-demand layers.